### PR TITLE
[dist] Update debug to 2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "expressjs/morgan",
   "dependencies": {
     "basic-auth": "~1.0.4",
-    "debug": "~2.2.0",
+    "debug": "~2.6.9",
     "depd": "~1.1.0",
     "on-finished": "~2.3.0",
     "on-headers": "~1.0.1"


### PR DESCRIPTION
`debug@2.2.0` has a vulnerability: https://nodesecurity.io/advisories/534